### PR TITLE
[ Feature ] - 전역 CSS 상태 관리 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,30 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
+import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import Nav from '@/components/Nav.vue';
+import { useUserStore } from '@/stores/user';
 
 const route = useRoute();
+const userStore = useUserStore();
+const { appThemeClass } = storeToRefs(userStore);
+const themeClassNames = ['theme-happy', 'theme-neutral', 'theme-regret'];
+
+// theme.css가 #app.theme-* 셀렉터를 기준으로 토큰을 바꾸므로 mount root에 클래스를 동기화
+const syncAppThemeClass = (nextThemeClass) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const appRoot = document.getElementById('app');
+
+  if (!appRoot) {
+    return;
+  }
+
+  appRoot.classList.remove(...themeClassNames);
+  appRoot.classList.add(nextThemeClass);
+};
 
 // login, signup 페이지에서는 Nav 숨기기
 const hideNav = computed(() => {
@@ -11,11 +32,16 @@ const hideNav = computed(() => {
   return path === '/login' || path === '/signup';
 });
 
+watch(
+  appThemeClass,
+  (nextThemeClass) => {
+    // 감정 비율이 바뀌면 App 루트 토큰도 바로 갱신
+    syncAppThemeClass(nextThemeClass);
+  },
+  { immediate: true }
+);
+
 const logoSrc = '/src/assets/icon/logo.svg';
-const textColor = 'linear-gradient(180deg, #F6E3A1 0%, #EFAF9E 100%)';
-const backGroundColor = '#FF8C00';
-const navBgColor = '#ffffff';
-const navBgColor1 = '#FFAAAA';
 const menus = [
   {
     key: 'home',
@@ -57,42 +83,15 @@ const menus = [
 
 <template>
   <div class="app-layout" :class="{ 'no-nav': hideNav }">
-    <Nav
-      v-if="!hideNav"
-      :menus="menus"
-      :logo-src="logoSrc"
-      :active-text-color="navBgColor"
-      :active-bg="backGroundColor"
-      :mobileMenuBg="navBgColor1"
-      :nav-bg="textColor"
-    />
+    <Nav v-if="!hideNav" :menus="menus" :logo-src="logoSrc" text-color="var(--nav-text)"
+      active-text-color="var(--nav-active-text)" active-bg="var(--nav-active-bg)"
+      mobile-menu-bg="var(--nav-mobile-menu-bg)" nav-bg="var(--nav-bg)" />
+    <!-- Nav 색상도 theme.css의 semantic token을 그대로 사용 -->
     <main class="content">
       <RouterView />
     </main>
   </div>
 </template>
-
-<style>
-/* 글로벌 리셋 — 브라우저 기본 margin/padding 제거 */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-}
-
-#app {
-  width: 100%;
-  min-height: 100vh;
-}
-</style>
 
 <style scoped>
 .app-layout {
@@ -104,6 +103,7 @@ body {
 /* ─── 데스크탑 (1025px+): 사이드바 25% → 콘텐츠 나머지 75% ─── */
 @media (min-width: 1025px) {
   .content {
+    /* 실제 배경색은 base.css / theme.css 토큰에서 가져오고 여기서는 레이아웃만 설정 */
     margin-left: 25%;
     width: 75%;
     min-height: 100vh;

--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -43,11 +43,30 @@ body {
   font-family: var(--font-family-base);
   color: var(--text-primary);
   background: var(--page-bg-home);
+  transition:
+    background 0.35s ease,
+    color 0.35s ease;
 }
 
 #app {
   width: 100%;
   min-height: 100vh;
+  color: var(--text-primary);
+  background:
+    var(--app-shell-overlay),
+    var(--app-shell-bg, var(--page-bg-home));
+  transition:
+    background 0.35s ease,
+    color 0.35s ease;
+}
+
+.app-layout {
+  color: inherit;
+}
+
+.app-layout > .content {
+  background: var(--app-content-bg, transparent);
+  transition: background 0.35s ease;
 }
 
 img,

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -74,12 +74,24 @@
   --nav-text: var(--neutral-nav-text);
   --nav-active-bg: var(--accent-primary);
   --nav-active-text: var(--neutral-white);
+  --nav-mobile-menu-bg: var(--surface-emphasis);
   --button-primary-bg: var(--accent-primary);
   --button-primary-text: var(--neutral-white);
   --button-secondary-bg: var(--accent-strong);
   --button-secondary-text: var(--neutral-black);
   --button-danger-bg: var(--neutral-danger-soft);
   --button-danger-text: var(--neutral-white);
+  --app-shell-bg: linear-gradient(
+    180deg,
+    var(--page-bg-home) 0%,
+    var(--page-bg-profile) 100%
+  );
+  --app-shell-overlay: radial-gradient(
+    circle at top,
+    rgba(255, 255, 255, 0.48) 0%,
+    transparent 38%
+  );
+  --app-content-bg: rgba(255, 251, 240, 0.7);
 
   /* Shape and effects -모양과 그림자 효과 등*/
   --radius-card: 20px;
@@ -159,12 +171,24 @@
   --nav-text: var(--happy-nav-text);
   --nav-active-bg: var(--accent-primary);
   --nav-active-text: var(--happy-white);
+  --nav-mobile-menu-bg: var(--surface-secondary);
   --button-primary-bg: var(--accent-primary);
   --button-primary-text: var(--happy-white);
   --button-secondary-bg: var(--accent-strong);
   --button-secondary-text: var(--happy-ink-900);
   --button-danger-bg: var(--happy-minus);
   --button-danger-text: var(--happy-white);
+  --app-shell-bg: linear-gradient(
+    180deg,
+    var(--page-bg-home) 0%,
+    var(--page-bg-profile) 100%
+  );
+  --app-shell-overlay: radial-gradient(
+    circle at top,
+    rgba(255, 255, 255, 0.55) 0%,
+    transparent 40%
+  );
+  --app-content-bg: rgba(255, 247, 217, 0.72);
 
   /* Shape and effects -모양과 그림자 효과 등*/
   --radius-card: 24px;
@@ -220,12 +244,24 @@
   --nav-text: var(--regret-black);
   --nav-active-bg: var(--regret-black);
   --nav-active-text: var(--regret-white);
+  --nav-mobile-menu-bg: var(--surface-secondary);
   --button-primary-bg: var(--regret-black);
   --button-primary-text: var(--regret-white);
   --button-secondary-bg: var(--regret-white);
   --button-secondary-text: var(--regret-black);
   --button-danger-bg: var(--regret-black);
   --button-danger-text: var(--regret-white);
+  --app-shell-bg: linear-gradient(
+    180deg,
+    var(--page-bg-home) 0%,
+    var(--surface-secondary) 100%
+  );
+  --app-shell-overlay: radial-gradient(
+    circle at top,
+    rgba(0, 0, 0, 0.04) 0%,
+    transparent 34%
+  );
+  --app-content-bg: rgba(255, 255, 255, 0.92);
 
   /* Shape and effects -모양과 그림자 효과 등*/
   --radius-card: 0;

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,10 @@ import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router';
 
+// global css
+import '@/assets/styles/base.css';
+import '@/assets/styles/theme.css';
+
 const app = createApp(App);
 
 app.use(createPinia());

--- a/src/pages/register/RegisterPage.vue
+++ b/src/pages/register/RegisterPage.vue
@@ -413,7 +413,10 @@ const saveTransaction = async () => {
 
   try {
     isSubmitting.value = true;
-    await api.post('/transactions', buildTransactionPayload());
+    const savedTransaction = await api.post('/transactions', buildTransactionPayload());
+
+    // 저장 직후 pinia userStore에도 반영해서 감정 집계와 전역 UI를 즉시 갱신
+    userStore.addTransaction(savedTransaction);
 
     alert("성공적으로 저장되었습니다!");
     // 저장 완료 후 폼 초기화

--- a/src/stores/USER_STORE_GUIDE.md
+++ b/src/stores/USER_STORE_GUIDE.md
@@ -11,6 +11,8 @@ const userStore = useUserStore();
 
 ## 상태
 
+### 원본 상태
+
 | 상태           | 타입           | 설명                  |
 | -------------- | -------------- | --------------------- |
 | `user`         | Object \| null | 로그인한 유저 정보    |
@@ -20,6 +22,33 @@ const userStore = useUserStore();
 userStore.user; // { id, userId, nickname, userLocation, selectedTitle, ... }
 userStore.transactions; // [{ id, user_id, type, amount, category, memo, emotion, date }, ...]
 ```
+
+### 파생 상태
+
+`transactions`를 기준으로 자동 계산되는 값들입니다.
+
+| 상태                  | 타입   | 설명                                                      |
+| --------------------- | ------ | --------------------------------------------------------- |
+| `expenseTransactions` | Array  | `type === 'expense'` 인 거래만 필터링한 목록              |
+| `happyCount`          | Number | 지출 중 `emotion === 'happy'` 인 건수                     |
+| `regretCount`         | Number | 지출 중 `emotion === 'regret'` 인 건수                    |
+| `happyRatio`          | Number | `happy / (happy + regret)` 비율. 값 범위는 `0 ~ 1`        |
+| `dominantEmotion`     | String | 비율 기준 감정 상태. `happy`, `regret`, `neutral` 중 하나 |
+| `appThemeClass`       | String | `App.vue` 등에 바로 바인딩할 수 있는 클래스명             |
+
+```js
+userStore.happyCount; // 3
+userStore.regretCount; // 2
+userStore.happyRatio; // 0.6
+userStore.dominantEmotion; // 'happy'
+userStore.appThemeClass; // 'theme-happy'
+```
+
+`dominantEmotion` 판정 기준은 아래와 같습니다.
+
+- `happyRatio >= 0.6` 이면 `happy`
+- `happyRatio <= 0.4` 이면 `regret`
+- 그 사이는 `neutral`
 
 ---
 
@@ -39,6 +68,22 @@ await userStore.login(userId, userPassword);
 userStore.logout(); // user, transactions 초기화
 ```
 
+### 거래 목록 교체
+
+API에서 받아온 거래 배열 전체를 store에 반영할 때 사용합니다.
+
+```js
+userStore.setTransactions(userTransactions);
+```
+
+### 거래 1건 추가
+
+지출/수입 등록 성공 직후 응답으로 받은 거래를 store에 바로 반영할 때 사용합니다.
+
+```js
+userStore.addTransaction(savedTransaction);
+```
+
 ---
 
 ## template에서 사용
@@ -46,6 +91,8 @@ userStore.logout(); // user, transactions 초기화
 ```html
 <p>{{ userStore.user?.nickname }}</p>
 <p>{{ userStore.transactions.length }}건</p>
+<p>만족 {{ userStore.happyCount }}건</p>
+<p>후회 {{ userStore.regretCount }}건</p>
 ```
 
 ---
@@ -58,8 +105,31 @@ userStore.logout(); // user, transactions 초기화
 import { storeToRefs } from 'pinia';
 
 const userStore = useUserStore();
-const { user, transactions } = storeToRefs(userStore);
-// user.value, transactions.value 로 접근
+const {
+  user,
+  transactions,
+  happyCount,
+  regretCount,
+  dominantEmotion,
+  appThemeClass,
+} = storeToRefs(userStore);
+// user.value, transactions.value, happyCount.value ... 로 접근
+```
+
+## App.vue에서 테마 클래스 사용
+
+```js
+import { storeToRefs } from 'pinia';
+import { useUserStore } from '@/stores/user';
+
+const userStore = useUserStore();
+const { appThemeClass } = storeToRefs(userStore);
+```
+
+```html
+<div class="app-layout" :class="appThemeClass">
+  <RouterView />
+</div>
 ```
 
 ---

--- a/src/stores/USER_STORE_GUIDE.md
+++ b/src/stores/USER_STORE_GUIDE.md
@@ -119,15 +119,26 @@ const {
 ## App.vue에서 테마 클래스 사용
 
 ```js
+import { watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUserStore } from '@/stores/user';
 
 const userStore = useUserStore();
 const { appThemeClass } = storeToRefs(userStore);
+
+watch(
+  appThemeClass,
+  (nextThemeClass) => {
+    const appRoot = document.getElementById('app');
+    appRoot?.classList.remove('theme-happy', 'theme-neutral', 'theme-regret');
+    appRoot?.classList.add(nextThemeClass);
+  },
+  { immediate: true }
+);
 ```
 
 ```html
-<div class="app-layout" :class="appThemeClass">
+<div class="app-layout">
   <RouterView />
 </div>
 ```

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,22 +1,88 @@
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
-import { loginUser, getUserById, getUserTransactions } from '@/service/user/userApi';
+import {
+  loginUser,
+  getUserById,
+  getUserTransactions,
+} from '@/service/user/userApi';
 
 export const useUserStore = defineStore('user', () => {
   const user = ref(null);
   const transactions = ref([]);
 
+  // 거래 목록은 항상 이 함수로 갱신해서 파생 상태 계산 기준을 한곳으로 (ex) 새 유저 로그인
+  const setTransactions = (nextTransactions = []) => {
+    transactions.value = Array.isArray(nextTransactions)
+      ? nextTransactions
+      : [];
+  };
+
+  // 등록 성공 직후 새 거래를 붙이면 관련 집계가 즉시 다시 계산
+  const addTransaction = (nextTransaction) => {
+    if (!nextTransaction) return;
+    transactions.value = [...transactions.value, nextTransaction];
+  };
+
+  // 감정 집계는 지출만 대상
+  const expenseTransactions = computed(() =>
+    transactions.value.filter((transaction) => transaction.type === 'expense')
+  );
+
+  const happyCount = computed(
+    () =>
+      expenseTransactions.value.filter(
+        (transaction) => transaction.emotion === 'happy'
+      ).length
+  );
+
+  const regretCount = computed(
+    () =>
+      expenseTransactions.value.filter(
+        (transaction) => transaction.emotion === 'regret'
+      ).length
+  );
+
+  const happyRatio = computed(() => {
+    const totalEmotionCount = happyCount.value + regretCount.value;
+
+    if (totalEmotionCount === 0) {
+      return 0;
+    }
+
+    return happyCount.value / totalEmotionCount;
+  });
+
+  // happy 비율이 60% 이상이면 happy, 40% 이하면 regret, 그 사이는 neutral
+  const dominantEmotion = computed(() => {
+    if (happyCount.value === 0 && regretCount.value === 0) {
+      return 'neutral';
+    }
+
+    if (happyRatio.value >= 0.6) {
+      return 'happy';
+    }
+
+    if (happyRatio.value <= 0.4) {
+      return 'regret';
+    }
+
+    return 'neutral';
+  });
+
+  // 실제 App에 적용될 css
+  const appThemeClass = computed(() => `theme-${dominantEmotion.value}`);
+
   const login = async (userId, userPassword) => {
     const loggedInUser = await loginUser(userId, userPassword);
     const userTransactions = await getUserTransactions(loggedInUser.id);
     user.value = loggedInUser;
-    transactions.value = userTransactions;
+    setTransactions(userTransactions);
     localStorage.setItem('userId', loggedInUser.id);
   };
 
   const logout = () => {
     user.value = null;
-    transactions.value = [];
+    setTransactions([]);
     localStorage.removeItem('userId');
   };
 
@@ -29,7 +95,7 @@ export const useUserStore = defineStore('user', () => {
         getUserTransactions(savedId),
       ]);
       user.value = restoredUser;
-      transactions.value = userTransactions;
+      setTransactions(userTransactions);
       return true;
     } catch {
       localStorage.removeItem('userId');
@@ -41,5 +107,20 @@ export const useUserStore = defineStore('user', () => {
     user.value = nextUser;
   };
 
-  return { user, transactions, login, logout, restoreSession, setUser };
+  return {
+    user,
+    transactions,
+    expenseTransactions,
+    happyCount,
+    regretCount,
+    happyRatio,
+    dominantEmotion,
+    appThemeClass,
+    login,
+    logout,
+    restoreSession,
+    setUser,
+    setTransactions,
+    addTransaction,
+  };
 });


### PR DESCRIPTION
## 관련 이슈

- Resolves : #35 
 
## 작업 사항

- RegisterPage에서 지출을 저장할 때 user.js의 userStore에도 거래를 추가함
- user.js에서는 새 거래가 저장될 때마다 happy / regret 카운트를 갱신하여 페이지에 적용할 CSS를 결정
- 적용할 CSS가 결정되면 App.vue에서 확인 후 갱신

## 참고 사항

- 아직 각 페이지의 로컬 css 처리 안해서 네비바만 변경되는 것처럼 보임
